### PR TITLE
Fix logout 401 error

### DIFF
--- a/frontend/js/ApiCalls.js
+++ b/frontend/js/ApiCalls.js
@@ -1,5 +1,5 @@
 import { navigateTo, initPages } from "./Router.js";
-import { showAlert } from "./Utils.js";
+import { isLoggedIn, showAlert } from "./Utils.js";
 import { getUserData, injectUserData, } from "./User.js";
 import { get_csrf_token, runEndPoint, updateInfo } from "./ApiUtils.js"
 import { getSubmittedInput, toggleModal } from "./DashboardUtils.js";
@@ -53,7 +53,7 @@ async function login(loginForm) {
 		button.innerText = await getKeyTranslation("connect_here");
 		button.classList.add("btn", "btn-sm", "btn-danger", "text-white", "ms-auto");
 		button.onclick = async () => {
-			response = await runEndPoint("users/update_is_online/", "POST", JSON.stringify({username: fetchBody.username, online: false}));
+			response = await runEndPoint("users/update_is_online/", "POST", JSON.stringify({ username: fetchBody.username, online: false }));
 			if (response.statusCode === 200)
 				login(loginForm);
 			else
@@ -66,11 +66,13 @@ async function login(loginForm) {
 }
 
 async function logout() {
-	var response = await runEndPoint("users/logout/", "POST",);
-	if (response.statusCode === 200) {
-		closeWs();
-		await initPages();
-		await navigateTo("/dash");
+	if (await isLoggedIn()) {
+		var response = await runEndPoint("users/logout/", "POST",);
+		if (response.statusCode === 200) {
+			closeWs();
+			await initPages();
+			await navigateTo("/dash");
+		}
 	}
 }
 

--- a/py_backend/py_backend/settings.py
+++ b/py_backend/py_backend/settings.py
@@ -44,6 +44,7 @@ FORTY_TWO_UID = 'u-s4t2ud-92889d666741a2b0d333c0b63e74d6491194432da0c98a38a82560
 FORTY_TWO_SECRET = os.environ.get("FORTY_TWO_SECRET")
 FORTY_TWO_REDIRECT_URI = 'https://127.0.0.1:8000/api/auth42/callback/'
 LANG = ['en', 'fr', 'es']
+IMAGE_EXTENSION = ['.png', '.PNG', '.jpg', '.JPG', '.jpeg', '.JPEG']
 
 # Application definition
 

--- a/py_backend/users/decorators.py
+++ b/py_backend/users/decorators.py
@@ -1,6 +1,5 @@
 from django.http import JsonResponse
 from django.contrib.auth.models import AnonymousUser
-from django.shortcuts import redirect
 
 def custom_login_required(func):
     def wrapper(request, *args, **kwargs):

--- a/py_backend/users/test/test_login.py
+++ b/py_backend/users/test/test_login.py
@@ -95,7 +95,7 @@ class LogoutTests(TestCase):
             reverse('logout'), 
             content_type='application/json')
         
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 302)
 
     def test_missing_password(self):
         user = {

--- a/py_backend/users/test/test_logout.py
+++ b/py_backend/users/test/test_logout.py
@@ -43,4 +43,4 @@ class LogoutTests(TestCase):
             reverse('logout'), 
             content_type='application/json')
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 302)

--- a/py_backend/users/utils.py
+++ b/py_backend/users/utils.py
@@ -110,11 +110,9 @@ def decode_json_body(request):
 
 def image_extension_is_valid(image_name):
 	name, ext = os.path.splitext(image_name)
-	if ext == '.png':
-		return True
-	if ext == '.jpg' or ext == '.jpeg' or ext == '.JPG' or ext == '.JPEG':
-		return True
-	return False
+	if ext not in settings.IMAGE_EXTENSION:
+		return False
+	return True
 
 
 def convert_image_to_base64(image_field):

--- a/py_backend/users/views/logout_view.py
+++ b/py_backend/users/views/logout_view.py
@@ -1,17 +1,22 @@
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import requires_csrf_token
-from users.decorators import custom_login_required as login_required
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth import logout
 from django.http import JsonResponse
+from users.models import CustomUser
 
 
 @require_http_methods(["POST"])
 @login_required
 @requires_csrf_token
 def logout_view(request):
-    user = request.user
-    user.save()
+    try:
+        user = request.user
+    except CustomUser.DoesNotExist:
+        return JsonResponse({"error": "user_not_found_message"}, status=404)
+    
     user.is_online = False
+    user.save()
     
     logout(request)
     return JsonResponse({'status': "logout_message"}, status=200)

--- a/py_backend/users/views/logout_view.py
+++ b/py_backend/users/views/logout_view.py
@@ -11,7 +11,7 @@ from django.http import JsonResponse
 def logout_view(request):
     user = request.user
     user.save()
-    user.isOnline = False
+    user.is_online = False
     
     logout(request)
     return JsonResponse({'status': "logout_message"}, status=200)


### PR DESCRIPTION
Now, the `logout` view uses the basic `@login_required` decorator for AnonymousUser management. I also added a try and except for more protection.

@maujogue be advised that the `logout` view returns a 302 status code if you try to logout while being not logged in.

EDIT: I also added a quick fix in `image_extension_valid` function, it's unrelated to the main subject of this PR.